### PR TITLE
fix: click on player did not work for all devices

### DIFF
--- a/components/video-player-stream.tsx
+++ b/components/video-player-stream.tsx
@@ -4,7 +4,7 @@ import classNames from 'classnames'
 import { detect } from 'detect-browser'
 import fetch from 'isomorphic-unfetch'
 import type { FC } from 'react'
-import { useCallback, useEffect, useRef, useState } from 'react'
+import { useCallback, useEffect, useState } from 'react'
 import useDimensions from 'react-cool-dimensions'
 
 import type { Video, StreamConfig } from '~/types'
@@ -18,8 +18,8 @@ const VideoPlayerStreamComponent: FC<VideoPlayerStreamProps> = ({
   onRequestClose,
   streamConfig: { videoConfig, chatConfig, actions, discordInviteUrl },
 }) => {
-  const videoIframe = useRef<HTMLIFrameElement>(null)
-  const videoPlayer = useRef<any | null>(null)
+  const [videoPlayer, setVideoPlayer] = useState<any | null>(null)
+  const [videoPlayerBusy, setVideoPlayerBusy] = useState<boolean>(false)
   const [videoPlaying, setVideoPlaying] = useState(false)
 
   const [browserName, setBrowserName] = useState<string | false | null>(null)
@@ -38,10 +38,21 @@ const VideoPlayerStreamComponent: FC<VideoPlayerStreamProps> = ({
     }
   }, [videoConfig])
 
-  const play = useCallback(() => {
-    videoPlayer.current?.[videoPlaying ? 'pause' : 'play']?.()
+  const play = () => {
+    videoPlayer?.[videoPlaying ? 'pause' : 'play']?.()
     setVideoPlaying(!videoPlaying)
-  }, [videoPlaying])
+  }
+
+  const onVideoIframeLoaded = async (el: HTMLIFrameElement | null) => {
+    if (el && !videoPlayer && !videoPlayerBusy) {
+      setVideoPlayerBusy(true)
+      const { PeerTubePlayer } = await import('@peertube/embed-api')
+      const pt = new PeerTubePlayer(el)
+      await pt.ready
+      setVideoPlayer(pt)
+      setVideoPlayerBusy(false)
+    }
+  }
 
   useEffect(() => {
     getVideo()
@@ -52,17 +63,6 @@ const VideoPlayerStreamComponent: FC<VideoPlayerStreamProps> = ({
       document.body.style.overflow = 'unset'
     }
   }, [videoConfig, chatConfig, getVideo])
-
-  useEffect(() => {
-    if (videoIframe.current && !videoPlayer.current)
-      (async () => {
-        const { PeerTubePlayer } = await import('@peertube/embed-api')
-        const pt = new PeerTubePlayer(videoIframe.current!)
-        await pt.ready
-        videoPlayer.current = pt
-        if (!videoPlaying) play()
-      })()
-  }, [play, videoPlaying])
 
   const [videoIframeHeight, setVideoIframeHeight] = useState(0)
   const windowWidth = useWindowWidth()
@@ -93,18 +93,22 @@ const VideoPlayerStreamComponent: FC<VideoPlayerStreamProps> = ({
               allowFullScreen
               className='lg:(h-full w-full)'
               frameBorder='0'
-              ref={videoIframe}
               width={width}
               height={videoIframeHeight}
               sandbox='allow-same-origin allow-scripts allow-popups'
               src={`https://${videoConfig.baseUrl}${video.embedPath}?api=1&controls=false`}
+              ref={onVideoIframeLoaded}
             />
             <div
-              className='absolute inset-center'
-              onClick={e => {
-                if (e.target === e.currentTarget) play()
-              }}
-            ></div>
+              className='absolute inset-0 flex justify-center items-center cursor-pointer'
+              onClick={() => play()}
+            >
+              {!videoPlaying && (
+                <button className='bg-white border p-2' type='button'>
+                  Play
+                </button>
+              )}
+            </div>
             <ul className='absolute inset-x-0 top-0 bottom-auto h-auto flex justify-between items-center p-2 pb-8 bg-gradient-to-b from-[rgba(0,0,0,0.5)] to-transparent text-white'>
               {actions?.map(({ text, href, target, color = 'inherit' }) => (
                 <li key={text}>
@@ -126,16 +130,6 @@ const VideoPlayerStreamComponent: FC<VideoPlayerStreamProps> = ({
                 ×
               </li>
             </ul>
-            {!videoPlaying && (
-              <div
-                className='absolute inset-0 flex justify-center items-center'
-                onClick={() => play()}
-              >
-                <button className='bg-white border p-2' type='button'>
-                  Play
-                </button>
-              </div>
-            )}
           </div>
           <iframe
             className='titanembed flex-1 lg:(flex-none)'

--- a/components/video-player-stream.tsx
+++ b/components/video-player-stream.tsx
@@ -127,12 +127,14 @@ const VideoPlayerStreamComponent: FC<VideoPlayerStreamProps> = ({
               </li>
             </ul>
             {!videoPlaying && (
-              <button
-                className='absolute h-auto w-auto inset-auto !inset-center bg-white border p-2'
+              <div
+                className='absolute inset-0 flex justify-center items-center'
                 onClick={() => play()}
               >
-                Play
-              </button>
+                <button className='bg-white border p-2' type='button'>
+                  Play
+                </button>
+              </div>
             )}
           </div>
           <iframe

--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,25 @@
+declare module '*.md' {
+  const content: string
+  export default content
+}
+
+declare module '*.styl' {
+  const content: { [className: string]: string }
+  export default content
+}
+
+declare module '@peertube/embed-api' {
+  export class PeerTubePlayer extends HTMLVideoElement {
+    ready: Promise<boolean>
+
+    constructor(iframe: HTMLIFrameElement)
+
+    setResolution(x: number): void
+    setVolume(x: number): void
+  }
+}
+
+declare module 'remark-react' {
+  const remark2react: Parameters<ReturnType<typeof import('remark')>['use']>[0]
+  export default remark2react
+}

--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,28 +1,3 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
-
-declare module '*.md' {
-  const content: string
-  export default content
-}
-
-declare module '*.styl' {
-  const content: { [className: string]: string }
-  export default content
-}
-
-declare module '@peertube/embed-api' {
-  export class PeerTubePlayer extends HTMLVideoElement {
-    ready: Promise<boolean>
-
-    constructor(iframe: HTMLIFrameElement)
-
-    setResolution(x: number): void
-    setVolume(x: number): void
-  }
-}
-
-declare module 'remark-react' {
-  const remark2react: Parameters<ReturnType<typeof import('remark')>['use']>[0]
-  export default remark2react
-}
+/// <reference types="next/image-types/global" />

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,5 +25,5 @@
     }
   },
   "exclude": ["node_modules"],
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx"]
+  "include": ["next-env.d.ts", "global.d.ts", "**/*.ts", "**/*.tsx"]
 }


### PR DESCRIPTION
- use callback ref to set video
- remove eager click event
- strip memoization on play
- expand click target