### PR TITLE
chore(dx): add lint action

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,4 +8,4 @@ jobs:
     - name: Install modules
       run: yarn
     - name: Run ESLint
-      run: eslint . --ext .js,.jsx,.ts,.tsx,.json,.jsonc
+      run: yarn lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,11 @@
+name: Lint
+on: push
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install modules
+      run: yarn
+    - name: Run ESLint
+      run: eslint . --ext .js,.jsx,.ts,.tsx,.json,.jsonc

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,7 +1,7 @@
 name: Lint
 on: push
 jobs:
-  build:
+  install_and_lint:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2

--- a/next.config.js
+++ b/next.config.js
@@ -1,7 +1,8 @@
+/* eslint-disable @typescript-eslint/no-var-requires */
 const WindiCSSWebpackPlugin = require('windicss-webpack-plugin').default
 
 module.exports = {
-  webpack(config, _options) {
+  webpack(config /*, _options */) {
     config.plugins.push(
       new WindiCSSWebpackPlugin({
         scan: {

--- a/package.json
+++ b/package.json
@@ -9,9 +9,10 @@
   ],
   "scripts": {
     "dev": "next",
+    "lint": "eslint . --ext .js,.jsx,.ts,.tsx,.json,.jsonc",
     "build": "next build",
     "start": "next start",
-    "storybook": "start-storybook"
+    "storybook": "start-storybook",
   },
   "dependencies": {
     "@notionhq/client": "^0.2.1",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint . --ext .js,.jsx,.ts,.tsx,.json,.jsonc",
     "build": "next build",
     "start": "next start",
-    "storybook": "start-storybook",
+    "storybook": "start-storybook"
   },
   "dependencies": {
     "@notionhq/client": "^0.2.1",


### PR DESCRIPTION
- chore: Add a lint action in response to #79 and past PRs, where a build failed exclusively due to lint errors, and unavailability of logs kept this in the dark. Now, contributors will be able to see lint results as a dedicated status check.
- chore: Add a `lint` npm script that can be run locally with `yarn lint -- --fix` to resolve linting issues, for contributors not using VS Code, or who have not installed recommended VS Code extensions.