### PR TITLE
chore: enable stale-while-revalidate for api

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,13 @@
+{
+  "headers": [
+    {
+      "source": "/api(.*)",
+      "headers": [
+        {
+          "key": "Cache-Control",
+          "value": "s-maxage=1, stale-while-revalidate"
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
sets Cache-Control headers to serve stale responses from the api first. the next app is already using the swr client for polling, so once this is in the content will load much faster initially then be swapped with the latest if there has been a change in the last 60 seconds