### PR TITLE
fix: font corrupted in safari

### DIFF
--- a/windi.config.ts
+++ b/windi.config.ts
@@ -104,8 +104,8 @@ export default defineConfig({
         'monospace',
       ],
       sans: [
-        'Helvetica Now Display',
-        // 'Helvetica Neue',
+        // 'Helvetica Now Display',
+        'Helvetica Neue',
         'Helvetica',
         // 'Arial',
         // 'sans-serif',


### PR DESCRIPTION
temporary hotfix